### PR TITLE
Bump engine-io.server to 6.3.2, engine.io-server-jetty to 6.2.1, jetty to v11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <groupId>me.mariodev</groupId>
     <artifactId>socketio-server-java-demo</artifactId>
     <version>1.0</version>
+
     <build>
         <plugins>
             
@@ -38,7 +39,7 @@
         <dependency>
             <groupId>io.socket</groupId>
             <artifactId>socket.io-server</artifactId>
-            <version>3.0.2</version>
+            <version>4.1.2</version>
        </dependency>
 
         <dependency>
@@ -50,37 +51,46 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.19.v20190610</version>
+          <version>${jetty.version}</version>
         </dependency>
         
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.19.v20190610</version>
+          <version>${jetty.version}</version>
         </dependency>
+
+      <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>2.0.17</version>
+      </dependency>
+
+      <!-- https://mvnrepository.com/artifact/org.eclipse.jetty.websocket/websocket-jetty-server -->
+      <dependency>
+        <groupId>org.eclipse.jetty.websocket</groupId>
+        <artifactId>websocket-jetty-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
         
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
-            <version>9.4.19.v20190610</version>
+          <version>${jetty.version}</version>
         </dependency>
-        
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
-            <version>9.4.19.v20190610</version>
-        </dependency>
-        
+
+
         <dependency>
             <groupId>io.socket</groupId>
             <artifactId>engine.io-server</artifactId>
-            <version>5.0.0</version>
+            <version>6.3.2</version>
         </dependency>
-        
+
         <dependency>
             <groupId>io.socket</groupId>
             <artifactId>engine.io-server-jetty</artifactId>
-            <version>5.0.0</version>
+            <version>6.2.1</version>
         </dependency>
 
     </dependencies>
@@ -88,6 +98,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <jetty.version>11.0.15</jetty.version>
     </properties>
 
 </project>

--- a/src/main/java/me/mariodev/socketio_server_java_demo/Main.java
+++ b/src/main/java/me/mariodev/socketio_server_java_demo/Main.java
@@ -1,6 +1,6 @@
 package me.mariodev.socketio_server_java_demo;
 
-import io.socket.emitter.Emitter;
+import io.socket.engineio.server.Emitter;
 import io.socket.socketio.server.SocketIoNamespace;
 import io.socket.socketio.server.SocketIoServer;
 import io.socket.socketio.server.SocketIoSocket;
@@ -8,7 +8,7 @@ import io.socket.socketio.server.SocketIoSocket;
 public class Main {
     public static void main (String[] args) {
         
-        final ServerWrapper serverWrapper = new ServerWrapper("127.0.0.1", 9092, null); // null means "allow all" as stated in https://github.com/socketio/engine.io-server-java/blob/f8cd8fc96f5ee1a027d9b8d9748523e2f9a14d2a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServerOptions.java#L26
+        final ServerWrapper serverWrapper = new ServerWrapper("0.0.0.0", 1081, null); // null means "allow all" as stated in https://github.com/socketio/engine.io-server-java/blob/f8cd8fc96f5ee1a027d9b8d9748523e2f9a14d2a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServerOptions.java#L26
         try {
             serverWrapper.startServer();
         } catch (Exception e) {
@@ -16,21 +16,18 @@ public class Main {
         }
         SocketIoServer server = serverWrapper.getSocketIoServer();
         SocketIoNamespace ns = server.namespace("/");
-        ns.on("connection", new Emitter.Listener() {
-            @Override
-            public void call(Object... args) {
-                SocketIoSocket socket = (SocketIoSocket) args[0];
-                System.out.println("Client " + socket.getId() + " (" + socket.getInitialHeaders().get("remote_addr") + ") has connected.");
+        ns.on("connection", emitter -> {
+            SocketIoSocket socket = (SocketIoSocket) emitter[0];
+            System.out.println("Client " + socket.getId() + " (" + socket.getInitialHeaders().get("remote_addr") + ") has connected.");
 
-                socket.on("message", new Emitter.Listener() {
-                    @Override
-                    public void call(Object... args) {
-                        System.out.println("[Client " + socket.getId() + "] " + args);
-                        socket.send("message", "test message", 1);
-                    }
-                });
-                
-            }
+            socket.on("message", new Emitter.Listener() {
+                @Override
+                public void call(Object... args1) {
+                    System.out.println("[Client " + socket.getId() + "] " + args1);
+                    socket.send("message", "test message", 1);
+                }
+            });
+
         });
         
     }

--- a/src/main/java/me/mariodev/socketio_server_java_demo/RemoteAddrFilter.java
+++ b/src/main/java/me/mariodev/socketio_server_java_demo/RemoteAddrFilter.java
@@ -1,5 +1,6 @@
 package me.mariodev.socketio_server_java_demo;
 
+import jakarta.servlet.Filter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -7,14 +8,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 
 /**
  * @source https://stackoverflow.com/a/23590606/8524395

--- a/src/main/java/me/mariodev/socketio_server_java_demo/SocketIoJettyWebsocketInitializerServlet.java
+++ b/src/main/java/me/mariodev/socketio_server_java_demo/SocketIoJettyWebsocketInitializerServlet.java
@@ -1,0 +1,30 @@
+package me.mariodev.socketio_server_java_demo;
+
+import io.socket.engineio.server.EngineIoServer;
+import io.socket.engineio.server.JettyWebSocketHandler;
+import jakarta.servlet.http.HttpServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
+
+public class SocketIoJettyWebsocketInitializerServlet extends HttpServlet {
+
+  private final EngineIoServer mEngineIoServer;
+
+  public SocketIoJettyWebsocketInitializerServlet(EngineIoServer engineIoServer) {
+    this.mEngineIoServer = engineIoServer;
+  }
+
+  public void init() {
+    // Retrieve the JettyWebSocketServerContainer.
+    JettyWebSocketServerContainer container = JettyWebSocketServerContainer.getContainer(
+        getServletContext());
+
+    // Configure the max message size to 128kb.
+    container.setMaxTextMessageSize(128 * 1024);
+
+    // Simple registration of our SocketIO WebSocket endpoint
+    container.addMapping(
+        "/socket.io/*",
+        (servletUpgradeRequest, servletUpgradeResponse) -> new JettyWebSocketHandler(mEngineIoServer));
+  }
+
+}


### PR DESCRIPTION
Bump engine-io.server to 6.3.2
Bump engine.io-server-jetty to 6.2.1,
Bump jetty to v11
Add slf4j-simple for error logging.
Add Jetty websocket init code for Jetty v11

Fixes #3 and #2 